### PR TITLE
Fix ccyycn.com's retrive keys function

### DIFF
--- a/SBSE.js
+++ b/SBSE.js
@@ -3501,7 +3501,7 @@ const siteHandlers = {
                     const $ele = $(ele);
                     const d = {
                         title: $ele.parent().prev().text().trim(),
-                        key: $ele.text().trim(),
+                        key: $ele.children("span").text().trim()
                     };
 
                     activator.pushKeyDetails(d);


### PR DESCRIPTION
Now when retriving keys on ccyycn.com, the word "复制" wont get retrive as well.