### PR TITLE
Convert SteamSpy API calls to HTTPS

### DIFF
--- a/SBSE.js
+++ b/SBSE.js
@@ -1905,7 +1905,7 @@ const steam = {
       if (o.key === 'games' && o.sync !== false) {
         GM_xmlhttpRequest({
           method: 'GET',
-          url: 'http://steamspy.com/api.php?request=all',
+          url: 'https://steamspy.com/api.php?request=all',
           onload(res) {
             try {
               const data = JSON.parse(res.response);

--- a/SBSE.user.js
+++ b/SBSE.user.js
@@ -1905,7 +1905,7 @@ const steam = {
       if (o.key === 'games' && o.sync !== false) {
         GM_xmlhttpRequest({
           method: 'GET',
-          url: 'http://steamspy.com/api.php?request=all',
+          url: 'https://steamspy.com/api.php?request=all',
 
           onload(res) {
             try {


### PR DESCRIPTION
Server returns a 301 Moved Permanently on the call to the HTTP service. This causes the entire TamperMonkey setup to fail, as it does not resolve it properly.